### PR TITLE
ENH : watch config files and libs

### DIFF
--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -8,6 +8,7 @@ function changed(event) {
 
 gulp.task('watch', ['build'], function () {
   gulp.watch([ paths.source ], [ 'es6', 'lint', browserSync.reload ]).on('change', changed);
+  gulp.watch([ paths.systemConfig, paths.config, paths.jspm ], [ 'move', browserSync.reload ]).on('change', changed);
   gulp.watch([ paths.html ], [ 'html', browserSync.reload ]).on('change', changed);
   gulp.watch([ paths.less ], [ 'less' ]).on('change', changed);
 });


### PR DESCRIPTION
Relative to issue #17 

Gulp now watches changes on config files and libs and restarts the browser with the updated code.
